### PR TITLE
Update lco-ingester version to add new metrics tag. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 
 RUN pip install numpy astropy matplotlib pyraf xhtml2pdf pathlib2 requests && rm -rf ~/.cache/pip
 
-RUN pip3 install lco_ingester>=0.1.4 kombu && rm -rf ~/.cache/pip
+RUN pip3 install lco_ingester>=2.1.11 kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.0.1.tar.gz \
         && tar -xzvf ds9.debian9.8.0.1.tar.gz -C /usr/local/bin \

--- a/bin/floydsauto
+++ b/bin/floydsauto
@@ -337,9 +337,11 @@ if __name__ == "__main__":
     if os.getenv('DO_INGEST'):
         for output_file in output_files:
             os.system('lco_ingest_frame --api-root {api_root} --auth-token {auth_token} \
-                       --bucket {bucket} {path}'.format(api_root=os.getenv('API_ROOT'),
-                                                        auth_token=os.getenv('AUTH_TOKEN'),
-                                                        bucket=os.getenv('BUCKET'), path=output_file))
+                       --bucket {bucket} --process-name {process_name} {path}'.format(api_root=os.getenv('API_ROOT'),
+                                                                               auth_token=os.getenv('AUTH_TOKEN'),
+                                                                               bucket=os.getenv('BUCKET'),
+                                                                               process_name=os.getenv('INGESTER_PROCESS_NAME'),
+                                                                               path=output_file))
 
     output_directory = os.path.join(option.output_directory, option.site, camera, option.day_obs,
                                     'specproc')

--- a/bin/floydsauto
+++ b/bin/floydsauto
@@ -338,10 +338,10 @@ if __name__ == "__main__":
         for output_file in output_files:
             os.system('lco_ingest_frame --api-root {api_root} --auth-token {auth_token} \
                        --bucket {bucket} --process-name {process_name} {path}'.format(api_root=os.getenv('API_ROOT'),
-                                                                               auth_token=os.getenv('AUTH_TOKEN'),
-                                                                               bucket=os.getenv('BUCKET'),
-                                                                               process_name=os.getenv('INGESTER_PROCESS_NAME'),
-                                                                               path=output_file))
+                                                                                      auth_token=os.getenv('AUTH_TOKEN'),
+                                                                                      bucket=os.getenv('BUCKET'),
+                                                                                      process_name=os.getenv('INGESTER_PROCESS_NAME'),
+                                                                                      path=output_file))
 
     output_directory = os.path.join(option.output_directory, option.site, camera, option.day_obs,
                                     'specproc')

--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -44,6 +44,8 @@ spec:
                   value: {{ .Values.opentsdbHostame | quote }}
                 - name: BOSUN_HOSTNAME
                   value: {{ .Values.bosunHostname | quote }}
+                - name: INGESTER_PROCESS_NAME
+                  value: {{ .Values.ingesterProcessName | quote }}
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,3 +19,5 @@ doIngest: 1
 opentsdbHostame: "opentsdb.lco.gtn"
 
 bosonHostname: "alerts.lco.gtn"
+
+ingesterProcessName: "floyds_pipeline"


### PR DESCRIPTION
Adds `--process-name` argument to `lco_ingest_frame`, plumbed through as an environment variable in the helm chart.