### PR TITLE
Add POSTPROCESS_FILES env var to deployment, set to False.

### DIFF
--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -47,6 +47,8 @@ spec:
                 - name: INGESTER_PROCESS_NAME
                   value: {{ .Values.ingesterProcessName | quote }}
                 - name: AWS_ACCESS_KEY_ID
+                - name: POSTPROCESS_FILES
+                  value: {{ .Values.postprocessFiles | quote }}
                   valueFrom:
                     secretKeyRef:
                       name: floydssecrets

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,3 +21,5 @@ opentsdbHostame: "opentsdb.lco.gtn"
 bosonHostname: "alerts.lco.gtn"
 
 ingesterProcessName: "floyds_pipeline"
+
+postprocessFiles: "False"


### PR DESCRIPTION
This disables posting image headers to the ES fitsheaders index from the ingester lib.