### PR TITLE
Update lco-ingester dependency version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 
 RUN pip install numpy astropy matplotlib pyraf xhtml2pdf pathlib2 requests && rm -rf ~/.cache/pip
 
-RUN pip3 install lco_ingester>=2.1.11 kombu && rm -rf ~/.cache/pip
+RUN pip3 install lco_ingester>=2.1.14 kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.0.1.tar.gz \
         && tar -xzvf ds9.debian9.8.0.1.tar.gz -C /usr/local/bin \


### PR DESCRIPTION
The lco-ingester library has been updated to version 2.1.14, which
itself contains an update to one of its dependencies,
opentsdb-python-metrics, which publishes metrics data on the standard
HTTP port 80 by default, rather than using a custom port number.

This behavior is also now configurable, rather than being hard-coded
into the library.

With this change, the LCO IT staff will be able to migrate the OpenTSDB
server to our newer hardware platform.