### PR TITLE
Fix/opentsdb port

### DIFF
--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -42,6 +42,8 @@ spec:
                   value: {{ .Values.bucket | quote }}
                 - name: OPENTSDB_HOSTNAME
                   value: {{ .Values.opentsdbHostame | quote }}
+                - name: OPENTSDB_PORT
+                  value: {{ .Values.opentsdbPort | quote }}
                 - name: BOSUN_HOSTNAME
                   value: {{ .Values.bosunHostname | quote }}
                 - name: INGESTER_PROCESS_NAME

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,5 +25,3 @@ bosonHostname: "alerts.lco.gtn"
 ingesterProcessName: "floyds_pipeline"
 
 postprocessFiles: "False"
-
-

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,8 +18,12 @@ doIngest: 1
 
 opentsdbHostame: "opentsdb.lco.gtn"
 
+opentsdbPort: 80
+
 bosonHostname: "alerts.lco.gtn"
 
 ingesterProcessName: "floyds_pipeline"
 
 postprocessFiles: "False"
+
+


### PR DESCRIPTION
The FLOYDS pipeline is crashing trying to submit metrics because it's attempting to read a value from `OPENTSDB_PORT`, which is somehow being set to some weird hostname. This forces the environment variable to be the correct value, which is 80.