### PR TITLE
make BUNIT keyword understandable by Astropy

### DIFF
--- a/src/floyds/floydsspecauto.py
+++ b/src/floyds/floydsspecauto.py
@@ -42,7 +42,7 @@ def fluxcalib2d(img2d,sensfun):  # flux calibrate 2d images
     floyds.util.delete(img2df)
     fits.writeto(img2df, float32(data2d), hdr2d)
     floyds.util.updateheader(img2df,0,{'SENSFUN'+_arm[0]:[string.split(sensfun,'/')[-1],'']})
-    floyds.util.updateheader(img2df,0,{'BUNIT':['erg/cm2/s/A  10^20','Physical unit of array values']})
+    floyds.util.updateheader(img2df,0,{'BUNIT':['10^20 erg / (Angstrom cm2 s)','Physical unit of array values']})
     return img2df
 
 def gettar(img):


### PR DESCRIPTION
This is a very simple change to the header information in automatically reduced FLOYDS spectra to make the data unit automatically parsable by the `astropy.units` module.