### PR TITLE
Update to use OCS Ingester 2.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 
 RUN pip install numpy astropy matplotlib pyraf xhtml2pdf pathlib2 requests && rm -rf ~/.cache/pip
 
-RUN pip3 install lco_ingester>=2.1.14 kombu && rm -rf ~/.cache/pip
+RUN pip3 install ocs_ingester>=2.2.5 kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.1.tar.gz \
         && tar -xzvf ds9.debian9.8.1.tar.gz -C /usr/local/bin \

--- a/bin/floydsauto
+++ b/bin/floydsauto
@@ -332,7 +332,7 @@ if __name__ == "__main__":
 
     if os.getenv('DO_INGEST'):
         for output_file in output_files:
-            os.system('lco_ingest_frame --api-root {api_root} --auth-token {auth_token} \
+            os.system('ocs_ingest_frame --api-root {api_root} --auth-token {auth_token} \
                        --bucket {bucket} --process-name {process_name} {path}'.format(api_root=os.getenv('API_ROOT'),
                                                                                       auth_token=os.getenv('AUTH_TOKEN'),
                                                                                       bucket=os.getenv('BUCKET'),


### PR DESCRIPTION
This ingester version includes updates related to the deletion of the "old" LCO s3 bucket. No functional changes.