### PR TITLE
Remove period from valid filename characters

### DIFF
--- a/src/floyds/util.py
+++ b/src/floyds/util.py
@@ -1109,5 +1109,5 @@ def mjdtoday():
 
 def to_safe_filename(unsafe_string):
     import string
-    valid_filename_characters = "-_.(){letters}{numbers}".format(letters=string.ascii_letters, numbers=string.digits)
+    valid_filename_characters = "-_(){letters}{numbers}".format(letters=string.ascii_letters, numbers=string.digits)
     return ''.join(character for character in unsafe_string if character in valid_filename_characters)


### PR DESCRIPTION
This is to ensure that the basename does not contain any extraneous periods. The ingester and most file naming conventions assume the first period is the delimiter between the basename and the extension.