### PR TITLE
Update ingester version and add filestore type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 RUN pip install setuptools==44.1.1
 RUN pip install numpy==1.16.6 astropy==2.0.16 pyraf==2.1.15 matplotlib==2.2.4 xhtml2pdf==0.2.4 pathlib2==2.3.5 requests==2.22.0 pytest==3.6.4 stsci.tools==3.6.0 && rm -rf ~/.cache/pip
 
-RUN pip3 install ocs_ingester>=2.2.5 kombu && rm -rf ~/.cache/pip
+RUN pip3 install 'ocs_ingester>=3.0.0,<4.0.0' kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.2.1.tar.gz \
         && tar -xzvf ds9.debian9.8.2.1.tar.gz -C /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 RUN pip install setuptools==44.1.1
 RUN pip install numpy==1.16.6 astropy==2.0.16 pyraf==2.1.15 matplotlib==2.2.4 xhtml2pdf==0.2.4 pathlib2==2.3.5 requests==2.22.0 pytest==3.6.4 stsci.tools==3.6.0 && rm -rf ~/.cache/pip
 
-RUN pip3 install 'ocs_ingester>=3.0.0,<4.0.0' kombu && rm -rf ~/.cache/pip
+RUN pip3 install --upgrade pip3 && pip3 install 'ocs_ingester>=3.0.0,<4.0.0' kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.2.1.tar.gz \
         && tar -xzvf ds9.debian9.8.2.1.tar.gz -C /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 RUN pip install setuptools==44.1.1
 RUN pip install numpy==1.16.6 astropy==2.0.16 pyraf==2.1.15 matplotlib==2.2.4 xhtml2pdf==0.2.4 pathlib2==2.3.5 requests==2.22.0 pytest==3.6.4 stsci.tools==3.6.0 && rm -rf ~/.cache/pip
 
-RUN pip3 install --upgrade pip && pip3 install 'ocs_ingester>=3.0.0,<4.0.0' kombu && rm -rf ~/.cache/pip
+RUN pip3 install ocs_ingester>=3.0.0 kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.2.1.tar.gz \
         && tar -xzvf ds9.debian9.8.2.1.tar.gz -C /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 RUN pip install setuptools==44.1.1
 RUN pip install numpy==1.16.6 astropy==2.0.16 pyraf==2.1.15 matplotlib==2.2.4 xhtml2pdf==0.2.4 pathlib2==2.3.5 requests==2.22.0 pytest==3.6.4 stsci.tools==3.6.0 && rm -rf ~/.cache/pip
 
-RUN pip3 install --upgrade pip3 && pip3 install 'ocs_ingester>=3.0.0,<4.0.0' kombu && rm -rf ~/.cache/pip
+RUN pip3 install --upgrade pip && pip3 install 'ocs_ingester>=3.0.0,<4.0.0' kombu && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.2.1.tar.gz \
         && tar -xzvf ds9.debian9.8.2.1.tar.gz -C /usr/local/bin \

--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -48,6 +48,8 @@ spec:
                   value: {{ .Values.bosunHostname | quote }}
                 - name: INGESTER_PROCESS_NAME
                   value: {{ .Values.ingesterProcessName | quote }}
+                - name : FILESTORE_TYPE
+                  value: {{ .Values.filestoreType | quote }}
                 - name: POSTPROCESS_FILES
                   value: {{ .Values.postprocessFiles | quote }}
                 - name: AWS_ACCESS_KEY_ID

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,3 +25,5 @@ bosonHostname: "alerts.lco.gtn"
 ingesterProcessName: "floyds_pipeline"
 
 postprocessFiles: "False"
+
+filestoreType: "s3"


### PR DESCRIPTION
Update floyds for new ingester version

We use the `ocs_ingest_frame` method here: https://github.com/LCOGT/floyds_pipeline/blob/63b024062fd8d394c2d9f2203d8db6bb502dc4e0/bin/floydsauto#L343

