### PR TITLE
add y2 for en05 to avoid crash

### DIFF
--- a/src/floyds/floydsspecdef.py
+++ b/src/floyds/floydsspecdef.py
@@ -2111,6 +2111,7 @@ def rectifyspectrum(img, arcfile, flatfile, fcfile, fcfile1, fcfile_untilt, _int
             if camera == 'en05':
                 xa, xb = 0, 1800
                 ya, yb = 186, 285
+                y2 = 'INDEF'
             elif camera == 'en12':
                 xa, xb = 0, 1792
                 ya, yb = 221, 312
@@ -2130,6 +2131,7 @@ def rectifyspectrum(img, arcfile, flatfile, fcfile, fcfile1, fcfile_untilt, _int
             if camera == 'en05':
                 xa, xb = 0, 1669
                 ya, yb = 125, 226
+                y2 = 100
             elif camera == 'en12':
                 xa, xb = 206, 1587
                 ya, yb = 182, 273

--- a/src/floyds/standard/ident/en05/fcuntilt_fts_blue
+++ b/src/floyds/standard/ident/en05/fcuntilt_fts_blue
@@ -1,0 +1,17 @@
+# 2019-06-25
+begin	untilt_fts_blue
+	task	fitcoords
+	axis	1
+	units	angstroms
+	surface	11
+		2.
+		2.
+		2.
+		1.
+		1.
+		1381.
+		1.
+		91.
+        690.
+        690 .
+        6.443042899058119

--- a/src/floyds/standard/ident/en05/fcuntilt_fts_red
+++ b/src/floyds/standard/ident/en05/fcuntilt_fts_red
@@ -1,0 +1,17 @@
+# 2019-06-25
+begin  untilt_fts_red
+   task   fitcoords
+   axis   1
+   units  angstroms
+   surface    11
+      2.
+      2.
+      2.
+      1.
+      1.
+      1791.
+      1.
+      91.
+      895.
+      895.
+      6.545263279835512


### PR DESCRIPTION
I don't know what this does, but without it we can't reduce old FLOYDS data. I'm assuming if this `y2` variable is the same for the en06 and en12, it's probably also the same for en05.